### PR TITLE
HostnameIdentifiedUrlGenerator getContext() return type fix

### DIFF
--- a/Router/HostnameIdentifiedLoader.php
+++ b/Router/HostnameIdentifiedLoader.php
@@ -30,9 +30,6 @@ final class HostnameIdentifiedLoader extends Loader
         $this->identifierMapping = $identifierMapping;
     }
 
-    /**
-     * @param mixed $resource
-     */
     public function load($resource, string $type = null): RouteCollection
     {
         $this->resourceStack[] = $resource;
@@ -55,9 +52,6 @@ final class HostnameIdentifiedLoader extends Loader
         return $collection;
     }
 
-    /**
-     * @param mixed $resource
-     */
     public function supports($resource, string $type = null): bool
     {
         return null === $type && !\in_array($resource, $this->resourceStack, true);

--- a/Router/HostnameIdentifiedUrlGenerator.php
+++ b/Router/HostnameIdentifiedUrlGenerator.php
@@ -33,9 +33,9 @@ final class HostnameIdentifiedUrlGenerator implements UrlGeneratorInterface
         $this->requestContext = $context;
     }
 
-    public function getContext(): ?RequestContext
+    public function getContext(): RequestContext
     {
-        return $this->requestContext;
+        return $this->requestContext ?? new RequestContext();
     }
 
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string

--- a/Router/PathIdentifiedUrlGenerator.php
+++ b/Router/PathIdentifiedUrlGenerator.php
@@ -30,9 +30,9 @@ final class PathIdentifiedUrlGenerator implements UrlGeneratorInterface
         $this->requestContext = $context;
     }
 
-    public function getContext(): ?RequestContext
+    public function getContext(): RequestContext
     {
-        return $this->requestContext;
+        return $this->requestContext ?? new RequestContext();
     }
 
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string

--- a/Site/IdentifierMapping.php
+++ b/Site/IdentifierMapping.php
@@ -39,9 +39,6 @@ final class IdentifierMapping implements IdentifierMappingInterface
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function findHostnamesByIdentifier(string $identifier, string $locale = null): array
     {
         if (!isset($this->mapping[$identifier])) {


### PR DESCRIPTION
Fix voor:


> PHP Fatal error:  Declaration of FH\Bundle\MultiSiteBundle\Router\HostnameIdentifiedUrlGenerator::getContext(): ?Symfony\Component\Routing\RequestContext must be compatible with Symfony\Component\Routing\RequestContextAwareInterface::getContext(): Symfony\Component\Routing\RequestContext


Zover als ik in de Symfony github heb kunnen terug zien is deze methode nooit nullable geweest.
Dus waarschijnlijk stond in HostnameIdentifiedUrlGenerator niet goed en is deze aanpassing wel backwards compatible.